### PR TITLE
Issue #14 fix pytest-depends/pytest-dependency plugin confusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "h5netcdf>=1.2.0",
     "openeo[localprocessing]",
     "cftime",
-    "pytest-dependency",
+    "pytest-depends",
     "pyarrow",
     "fastparquet"
 ]


### PR DESCRIPTION
pyproject.toml defined `pytest-dependency` as plugin, but test code used `pytest-depends` style.