### PR TITLE
Fix inter-testfile import issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ testpaths = [
   "tests",
 ]
 addopts = [
-  "--import-mode=importlib",
+  "--import-mode=prepend",
 ]
 
 [tool.isort]


### PR DESCRIPTION
fixes #13 
use "prepend" mode again,
instead of newer "importlib" which does not allow inter-testfile imports