### PR TITLE
GH Actions lint finetuning

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install 'isort==5.12.0' ruff
+        python -m pip install 'isort==5.12.0' 'ruff==0.1.15'
     - name: isort
       run: python -m isort . --check --diff
     # - name: black

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install isort black ruff
+        python -m pip install 'isort==5.12.0' ruff
     - name: isort
       run: python -m isort . --check --diff
     # - name: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
       - id: black
         language_version: python3.9
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: "5.12.0"
     hooks:
       - id: isort
         name: isort (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,9 @@ repos:
       - id: isort
         name: isort (python)
         args: ["--profile", "black"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.15
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: ["--fix"]


### PR DESCRIPTION
related to #16 

some minor finetuning:
- make sure same isort version is used in GH actions and pre-commit
- add ruff as pre-commit rule (as added in #25) 