### PR TITLE
User-defined asset definitions in STAC metadata

### DIFF
--- a/examples/extraction_pipelines/S2_extraction_example.ipynb
+++ b/examples/extraction_pipelines/S2_extraction_example.ipynb
@@ -19,6 +19,159 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Optional: define STAC metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The user can define a dicitionary containing the definition of all the assets that will be generated in this pipeline (https://github.com/stac-extensions/item-assets) to be added to the final STAC collection metadata of the extraction. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example we will be extracting 64x64 Sentinel-2 patches as netCDF, and additionally, in the post-job actions, we will add some auxiliary ground truth data as netCDF. Therefore we define the asset definitions below, such that they can be added to the STAC collection metadata in the end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pystac\n",
+    "\n",
+    "# Define the sentinel 2 asset\n",
+    "sentinel2_asset = pystac.extensions.item_assets.AssetDefinition(\n",
+    "    {\n",
+    "        \"gsd\": 10,\n",
+    "        \"title\": \"Sentinel2\",\n",
+    "        \"description\": \"Sentinel-2 bands\",\n",
+    "        \"type\": \"application/x-netcdf\",\n",
+    "        \"roles\": [\"data\"],\n",
+    "        \"proj:shape\": [64, 64],\n",
+    "        \"raster:bands\": [{\"name\": \"S2-L2A-B01\"}, \n",
+    "                         {\"name\": \"S2-L2A-B02\"},\n",
+    "                         {\"name\": \"S2-L2A-B03\"},\n",
+    "                         {\"name\": \"S2-L2A-B04\"},\n",
+    "                         {\"name\": \"S2-L2A-B05\"},\n",
+    "                         {\"name\": \"S2-L2A-B06\"},\n",
+    "                         {\"name\": \"S2-L2A-B07\"},\n",
+    "                         {\"name\": \"S2-L2A-B8A\"},\n",
+    "                         {\"name\": \"S2-L2A-B08\"},\n",
+    "                         {\"name\": \"S2-L2A-B11\"},\n",
+    "                         {\"name\": \"S2-L2A-B12\"},\n",
+    "                         {\"name\": \"S2-L2A-SCL\"}],\n",
+    "        \"cube:variables\": {\n",
+    "            \"S2-L2A-B01\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B02\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B03\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B04\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B05\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B06\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B07\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B8A\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B08\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B11\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-B12\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "            \"S2-L2A-SCL\": {\"dimensions\": [\"time\", \"y\", \"x\"], \"type\": \"data\"},\n",
+    "        },\n",
+    "        \"eo:bands\": [\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B01\",\n",
+    "                \"common_name\": \"coastal\",\n",
+    "                \"center_wavelength\": 0.443,\n",
+    "                \"full_width_half_max\": 0.027,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B02\",\n",
+    "                \"common_name\": \"blue\",\n",
+    "                \"center_wavelength\": 0.49,\n",
+    "                \"full_width_half_max\": 0.098,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B03\",\n",
+    "                \"common_name\": \"green\",\n",
+    "                \"center_wavelength\": 0.56,\n",
+    "                \"full_width_half_max\": 0.045,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B04\",\n",
+    "                \"common_name\": \"red\",\n",
+    "                \"center_wavelength\": 0.665,\n",
+    "                \"full_width_half_max\": 0.038,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B05\",\n",
+    "                \"common_name\": \"rededge\",\n",
+    "                \"center_wavelength\": 0.704,\n",
+    "                \"full_width_half_max\": 0.019,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B06\",\n",
+    "                \"common_name\": \"rededge\",\n",
+    "                \"center_wavelength\": 0.74,\n",
+    "                \"full_width_half_max\": 0.018,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B07\",\n",
+    "                \"common_name\": \"rededge\",\n",
+    "                \"center_wavelength\": 0.783,\n",
+    "                \"full_width_half_max\": 0.028,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B08\",\n",
+    "                \"common_name\": \"nir\",\n",
+    "                \"center_wavelength\": 0.842,\n",
+    "                \"full_width_half_max\": 0.145,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B8A\",\n",
+    "                \"common_name\": \"nir08\",\n",
+    "                \"center_wavelength\": 0.865,\n",
+    "                \"full_width_half_max\": 0.033,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B11\",\n",
+    "                \"common_name\": \"swir16\",\n",
+    "                \"center_wavelength\": 1.61,\n",
+    "                \"full_width_half_max\": 0.143,\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"S2-L2A-B12\",\n",
+    "                \"common_name\": \"swir22\",\n",
+    "                \"center_wavelength\": 2.19,\n",
+    "                \"full_width_half_max\": 0.242,\n",
+    "            },\n",
+    "        ],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# Define auxiliary asset:\n",
+    "auxiliary_asset = pystac.extensions.item_assets.AssetDefinition(\n",
+    "    {\n",
+    "        \"title\": \"ground truth data\",\n",
+    "        \"description\": \"This asset contains the crop type codes.\",\n",
+    "        \"type\": \"application/x-netcdf\",\n",
+    "        \"roles\": [\"data\"],\n",
+    "        \"proj:shape\": [64, 64],\n",
+    "        \"raster:bands\": [{\"name\": \"CROPTYPE\", \"data_type\": \"uint16\", \"bits_per_sample\": 16}],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "item_assets = {\n",
+    "    \"sentinel2\": sentinel2_asset,\n",
+    "    \"axuiliary\": auxiliary_asset\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Setting up the logging module "
    ]
   },
@@ -398,13 +551,12 @@
     "\n",
     "The post-job action must return back the list of job items. The user is responsible for updating,\n",
     "adding and removing the items. For example, in this case the user creates a raster file with\n",
-    "ground truth data, the user then adds an asset using the predefined `openeo_gfmap.stac.AUXILIARY`\n",
-    "AssetDefintion to the related item, pointing to the generated NetCDF file."
+    "ground truth data, the user then adds an asset using the predefined auxiliary asset definition, defined at the top of the notebook, to the related item, pointing to the generated NetCDF file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,24 +564,11 @@
     "from importlib.metadata import version\n",
     "from datetime import datetime\n",
     "\n",
-    "import pystac\n",
     "from pyproj import CRS\n",
     "from shapely.geometry import box\n",
     "from rasterio.features import rasterize\n",
     "from rasterio.transform import from_bounds\n",
     "# from openeo_gfmap.stac import AUXILIARY\n",
-    "\n",
-    "# Define auxiliary asset:\n",
-    "auxiliary_asset = pystac.extensions.item_assets.AssetDefinition(\n",
-    "    {\n",
-    "        \"title\": \"ground truth data\",\n",
-    "        \"description\": \"This asset contains the crop type codes.\",\n",
-    "        \"type\": \"application/x-netcdf\",\n",
-    "        \"roles\": [\"data\"],\n",
-    "        \"proj:shape\": [64, 64],\n",
-    "        \"raster:bands\": [{\"name\": \"CROPTYPE\", \"data_type\": \"uint16\", \"bits_per_sample\": 16}],\n",
-    "    }\n",
-    ")\n",
     "\n",
     "def add_item_asset(related_item: pystac.Item, path: Path):\n",
     "    asset = auxiliary_asset.create_asset(\n",
@@ -547,25 +686,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,7 +704,7 @@
     "from openeo_gfmap.backend import cdse_staging_connection\n",
     "\n",
     "\n",
-    "base_output_dir = Path('/data/users/Public/couchard/world_cereal/extractions_bys2tile_4/')\n",
+    "base_output_dir = Path('/data/users/Public/vincent.verelst/world_cereal/extractions/')\n",
     "tracking_job_csv = base_output_dir / 'job_tracker.csv'\n",
     "\n",
     "manager = GFMAPJobManager(\n",
@@ -597,69 +727,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-03-20 11:32:22,783|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
-      "2024-03-20 11:32:22,784|openeo_gfmap.manager|INFO:  Creating and running jobs.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-03-20 11:32:22,790|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
-      "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
-      "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
-      "      dtype='object')\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Authenticated using refresh token.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-03-20 11:32:24,137|openeo_gfmap.manager|DEBUG:  Status of job j-24032058198e49aebbde5f6041ffa3d7 is finished (on backend cdse-staging).\n",
-      "2024-03-20 11:32:24,138|openeo_gfmap.manager|INFO:  Job j-24032058198e49aebbde5f6041ffa3d7 finished successfully, queueing on_job_done...\n",
-      "2024-03-20 11:32:24,662|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_0.nc from job j-24032058198e49aebbde5f6041ffa3d7...\n",
-      "2024-03-20 11:32:28,082|openeo_gfmap.manager|DEBUG:  Downloaded openEO_0.nc from job j-24032058198e49aebbde5f6041ffa3d7 -> /data/users/Public/couchard/world_cereal/extractions_bys2tile_4/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2195082011/S2-L2A-10m_2021_BE_Flanders_full_2195082011_32631_2020-08-30_2022-03-03.nc\n",
-      "2024-03-20 11:32:29,939|openeo_gfmap.manager|INFO:  Parsed item j-24032058198e49aebbde5f6041ffa3d7_openEO_0.nc from job j-24032058198e49aebbde5f6041ffa3d7\n",
-      "2024-03-20 11:32:29,941|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-24032058198e49aebbde5f6041ffa3d7...\n",
-      "2024-03-20 11:32:30,806|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
-      "2024-03-20 11:32:30,807|openeo_gfmap.manager|INFO:  Job j-24032058198e49aebbde5f6041ffa3d7 and post job action finished successfully.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Define auxiliary asset:\n",
-    "import pystac\n",
-    "auxiliary_asset = pystac.extensions.item_assets.AssetDefinition(\n",
-    "    {\n",
-    "        \"title\": \"ground truth data\",\n",
-    "        \"description\": \"This asset contains the crop type codes.\",\n",
-    "        \"type\": \"application/x-netcdf\",\n",
-    "        \"roles\": [\"data\"],\n",
-    "        \"proj:shape\": [64, 64],\n",
-    "        \"raster:bands\": [{\"name\": \"CROPTYPE\", \"data_type\": \"uint16\", \"bits_per_sample\": 16}],\n",
-    "    }\n",
-    ")\n",
-    "\n",
-    "\n",
     "\n",
     "# Run the jobs and create the STAC catalogue\n",
     "manager.run_jobs(job_df, create_datacube_s2, tracking_job_csv)\n",
     "# In the post job actions, an extra 'auxiliary' asset was added to each item. The asset definition is therefore also added to the item_asset_definitions extensions of the final STAC collection\n",
-    "manager.create_stac(asset_definitions={'auxiliary': auxiliary_asset})  # By default the STAC catalogue will be saved in the stac subfolder of the base_output_dir folder."
+    "manager.create_stac(constellation='sentinel2', item_assets=item_assets)  # By default the STAC catalogue will be saved in the stac subfolder of the base_output_dir folder."
    ]
   }
  ],

--- a/src/openeo_gfmap/stac/constants.py
+++ b/src/openeo_gfmap/stac/constants.py
@@ -16,203 +16,35 @@ STAC_EXTENSIONS = [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
 ]
-CONSTELLATION = ["sentinel-2"]
-PLATFORM = ["sentinel-2a", "sentinel-2b"]
-INSTRUMENTS = ["msi"]
-GSD = [10, 20, 60]
-SUMMARIES = pystac.Summaries(
-    {
-        "constellation": CONSTELLATION,
-        "platform": PLATFORM,
-        "instruments": INSTRUMENTS,
-        "gsd": GSD,
-    }
-)
-
-
-def create_spatial_dimension(
-    name: str,
-) -> pystac.extensions.datacube.HorizontalSpatialDimension:
-    return pystac.extensions.datacube.HorizontalSpatialDimension(
-        {
-            "axis": name,
-            "step": 10,
-            "reference_system": {
-                "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
-                "area": "World",
-                "bbox": {
-                    "east_longitude": 180,
-                    "north_latitude": 90,
-                    "south_latitude": -90,
-                    "west_longitude": -180,
-                },
-                "coordinate_system": {
-                    "axis": [
-                        {
-                            "abbreviation": "Lat",
-                            "direction": "north",
-                            "name": "Geodetic latitude",
-                            "unit": "degree",
-                        },
-                        {
-                            "abbreviation": "Lon",
-                            "direction": "east",
-                            "name": "Geodetic longitude",
-                            "unit": "degree",
-                        },
-                    ],
-                    "subtype": "ellipsoidal",
-                },
-                "datum": {
-                    "ellipsoid": {
-                        "inverse_flattening": 298.257223563,
-                        "name": "WGS 84",
-                        "semi_major_axis": 6378137,
-                    },
-                    "name": "World Geodetic System 1984",
-                    "type": "GeodeticReferenceFrame",
-                },
-                "id": {"authority": "OGC", "code": "Auto42001", "version": "1.3"},
-                "name": "AUTO 42001 (Universal Transverse Mercator)",
-                "type": "GeodeticCRS",
-            },
-        }
-    )
-
-
-TEMPORAL_DIMENSION = pystac.extensions.datacube.TemporalDimension(
-    {"extent": ["2015-06-23T00:00:00Z", "2019-07-10T13:44:56Z"], "step": "P5D"}
-)
-
-BANDS_DIMENSION = pystac.extensions.datacube.AdditionalDimension(
-    {
-        "values": [
-            "S2-L2A-SCL",
-            "S2-L2A-B01",
-            "S2-L2A-B02",
-            "S2-L2A-B03",
-            "S2-L2A-B04",
-            "S2-L2A-B05",
-            "S2-L2A-B06",
-            "S2-L2A-B07",
-            "S2-L2A-B08",
-            "S2-L2A-B8A",
-            "S2-L2A-B09",
-            "S2-L2A-B10",
-            "S2-L2A-B11",
-            "S2-L2A-B12",
-            "LABEL",
-        ]
-    }
-)
-
-CUBE_DIMENSIONS = {
-    "x": create_spatial_dimension("x"),
-    "y": create_spatial_dimension("y"),
-    "time": TEMPORAL_DIMENSION,
-    "spectral": BANDS_DIMENSION,
+CONSTELLATION = {
+    "sentinel2": ["sentinel-2"],
+    "sentinel1": ["sentinel-1"],
 }
 
-SENTINEL2 = pystac.extensions.item_assets.AssetDefinition(
-    {
-        "gsd": 10,
-        "title": "Sentinel2",
-        "description": "Sentinel-2 bands",
-        "type": "application/x-netcdf",
-        "roles": ["data"],
-        "proj:shape": [64, 64],
-        "raster:bands": [{"name": "S2-L2A-B01"}, {"name": "S2-L2A-B02"}],
-        "cube:variables": {
-            "S2-L2A-B01": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B02": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B03": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B04": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B05": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B06": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B07": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B8A": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B08": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B11": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-B12": {"dimensions": ["time", "y", "x"], "type": "data"},
-            "S2-L2A-SCL": {"dimensions": ["time", "y", "x"], "type": "data"},
-        },
-        "eo:bands": [
-            {
-                "name": "S2-L2A-B01",
-                "common_name": "coastal",
-                "center_wavelength": 0.443,
-                "full_width_half_max": 0.027,
-            },
-            {
-                "name": "S2-L2A-B02",
-                "common_name": "blue",
-                "center_wavelength": 0.49,
-                "full_width_half_max": 0.098,
-            },
-            {
-                "name": "S2-L2A-B03",
-                "common_name": "green",
-                "center_wavelength": 0.56,
-                "full_width_half_max": 0.045,
-            },
-            {
-                "name": "S2-L2A-B04",
-                "common_name": "red",
-                "center_wavelength": 0.665,
-                "full_width_half_max": 0.038,
-            },
-            {
-                "name": "S2-L2A-B05",
-                "common_name": "rededge",
-                "center_wavelength": 0.704,
-                "full_width_half_max": 0.019,
-            },
-            {
-                "name": "S2-L2A-B06",
-                "common_name": "rededge",
-                "center_wavelength": 0.74,
-                "full_width_half_max": 0.018,
-            },
-            {
-                "name": "S2-L2A-B07",
-                "common_name": "rededge",
-                "center_wavelength": 0.783,
-                "full_width_half_max": 0.028,
-            },
-            {
-                "name": "S2-L2A-B08",
-                "common_name": "nir",
-                "center_wavelength": 0.842,
-                "full_width_half_max": 0.145,
-            },
-            {
-                "name": "S2-L2A-B8A",
-                "common_name": "nir08",
-                "center_wavelength": 0.865,
-                "full_width_half_max": 0.033,
-            },
-            {
-                "name": "S2-L2A-B11",
-                "common_name": "swir16",
-                "center_wavelength": 1.61,
-                "full_width_half_max": 0.143,
-            },
-            {
-                "name": "S2-L2A-B12",
-                "common_name": "swir22",
-                "center_wavelength": 2.19,
-                "full_width_half_max": 0.242,
-            },
-        ],
-    }
-)
+PLATFORM = {
+    "sentinel2": ["sentinel-2a", "sentinel-2b"],
+    "sentinel1": ["sentinel-1a", "sentinel-1b"],
+}
 
-SENTINEL1 = pystac.extensions.item_assets.AssetDefinition({})
+INSTRUMENTS = {"sentinel2": ["msi"], "sentinel1": ["c-sar"]}
 
-AGERA5 = pystac.extensions.item_assets.AssetDefinition({})
+GSD = {"sentinel2": [10, 20, 60], "sentinel1": [10]}
 
-ITEM_ASSETS = {
-    "sentinel2": SENTINEL2,
-    "sentinel1": SENTINEL1,
-    "agera5": AGERA5,
+SUMMARIES = {
+    "sentinel2": pystac.summaries.Summaries(
+        {
+            "constellation": CONSTELLATION["sentinel2"],
+            "platform": PLATFORM["sentinel2"],
+            "instruments": INSTRUMENTS["sentinel2"],
+            "gsd": GSD["sentinel2"],
+        }
+    ),
+    "sentinel1": pystac.summaries.Summaries(
+        {
+            "constellation": CONSTELLATION["sentinel1"],
+            "platform": PLATFORM["sentinel1"],
+            "instruments": INSTRUMENTS["sentinel1"],
+            "gsd": GSD["sentinel1"],
+        }
+    ),
 }


### PR DESCRIPTION
The 'cube:dimensions' and 'item_assets' STAC extensions were hardcoded in gfmap. However, both are dependent on the extraction pipeline (i.e. which dimensions, bands, constellations, etc. are extracted), therefore they need to be user defined.

- The 'cube:dimensions' extension was removed, since one STAC collection can contain multiple types of datacubes (e.g. sentinel-2 + ground truth data)
- The 'item_assets' extension was made user-defined. Up until now it was possible for a user to add an extra asset definition, but there were also hardcoded definitions. All hardcoded asset definitions are removed; all definitions are now required to be defined by the user
- The sentinel-2 extraction example notebook has been updated following these changes