### PR TITLE
Issue94 extend stac collection

### DIFF
--- a/examples/extraction_pipelines/S2_extraction_example.ipynb
+++ b/examples/extraction_pipelines/S2_extraction_example.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -292,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -483,7 +483,7 @@
        "[222 rows x 8 columns]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -527,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +538,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -601,7 +601,7 @@
        "0            1  "
       ]
      },
-     "execution_count": 19,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -633,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -793,7 +793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -805,7 +805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -846,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -925,7 +925,7 @@
     "            all_touched=False,\n",
     "            fill=fill_value,\n",
     "            default_value=0,\n",
-    "            dtype='int64'\n",
+    "            dtype='int32'\n",
     "        )\n",
     "\n",
     "        # Create the attributes to add to the metadata\n",
@@ -997,7 +997,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1015,7 +1015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1046,22 +1046,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-04-19 13:09:53,046|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
-      "2024-04-19 13:09:53,046|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
-      "2024-04-19 13:09:53,048|openeo_gfmap.manager|INFO:  Creating and running jobs.\n",
-      "2024-04-19 13:09:53,048|openeo_gfmap.manager|INFO:  Creating and running jobs.\n",
-      "2024-04-19 13:09:53,203|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
+      "2024-04-19 14:02:59,136|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
+      "2024-04-19 14:02:59,136|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
+      "2024-04-19 14:02:59,136|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
+      "2024-04-19 14:02:59,138|openeo_gfmap.manager|INFO:  Creating and running jobs.\n",
+      "2024-04-19 14:02:59,138|openeo_gfmap.manager|INFO:  Creating and running jobs.\n",
+      "2024-04-19 14:02:59,138|openeo_gfmap.manager|INFO:  Creating and running jobs.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-04-19 14:02:59,516|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
       "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
       "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
       "      dtype='object')\n",
-      "2024-04-19 13:09:53,203|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
+      "2024-04-19 14:02:59,516|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
+      "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
+      "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
+      "      dtype='object')\n",
+      "2024-04-19 14:02:59,516|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
       "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
       "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
       "      dtype='object')\n"
@@ -1080,40 +1092,63 @@
      "text": [
       "/home/vverelst/anaconda3/envs/openeo-gfmap/lib/python3.9/site-packages/openeo/rest/connection.py:1189: UserWarning: SENTINEL2_L2A property filtering with properties that are undefined in the collection metadata (summaries): tileId.\n",
       "  return DataCube.load_collection(\n",
-      "2024-04-19 13:09:55,512|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
-      "2024-04-19 13:09:55,512|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
-      "2024-04-19 13:11:39,648|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:11:39,648|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:12:40,465|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:12:40,465|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:13:41,391|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:13:41,391|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:14:42,226|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:14:42,226|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:15:43,350|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:15:43,350|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:16:44,219|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:16:44,219|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:17:45,007|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:17:45,007|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
-      "2024-04-19 13:18:46,035|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is finished (on backend cdse).\n",
-      "2024-04-19 13:18:46,035|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is finished (on backend cdse).\n",
-      "2024-04-19 13:18:46,038|openeo_gfmap.manager|INFO:  Job j-2404196e403346cfa2a098dd008cb329 finished successfully, queueing on_job_done...\n",
-      "2024-04-19 13:18:46,038|openeo_gfmap.manager|INFO:  Job j-2404196e403346cfa2a098dd008cb329 finished successfully, queueing on_job_done...\n",
-      "2024-04-19 13:18:47,389|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329...\n",
-      "2024-04-19 13:18:47,389|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329...\n",
-      "2024-04-19 13:19:03,634|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329 -> /data/users/Public/vincent.verelst/world_cereal/test_load_stac/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2194075736/S2-L2A-10m_2021_BE_Flanders_full_2194075736_32631_2020-08-30_2022-03-03.nc\n",
-      "2024-04-19 13:19:03,634|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329 -> /data/users/Public/vincent.verelst/world_cereal/test_load_stac/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2194075736/S2-L2A-10m_2021_BE_Flanders_full_2194075736_32631_2020-08-30_2022-03-03.nc\n",
-      "2024-04-19 13:19:07,115|openeo_gfmap.manager|INFO:  Parsed item openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329\n",
-      "2024-04-19 13:19:07,115|openeo_gfmap.manager|INFO:  Parsed item openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329\n",
-      "2024-04-19 13:19:07,118|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404196e403346cfa2a098dd008cb329...\n",
-      "2024-04-19 13:19:07,118|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404196e403346cfa2a098dd008cb329...\n",
-      "2024-04-19 13:19:12,145|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
-      "2024-04-19 13:19:12,145|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
-      "2024-04-19 13:19:12,149|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
-      "2024-04-19 13:19:12,149|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
-      "2024-04-19 13:19:12,151|openeo_gfmap.manager|INFO:  Job j-2404196e403346cfa2a098dd008cb329 and post job action finished successfully.\n",
-      "2024-04-19 13:19:12,151|openeo_gfmap.manager|INFO:  Job j-2404196e403346cfa2a098dd008cb329 and post job action finished successfully.\n"
+      "2024-04-19 14:03:01,960|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
+      "2024-04-19 14:03:01,960|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
+      "2024-04-19 14:03:01,960|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
+      "2024-04-19 14:04:29,450|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is created (on backend cdse).\n",
+      "2024-04-19 14:04:29,450|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is created (on backend cdse).\n",
+      "2024-04-19 14:04:29,450|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is created (on backend cdse).\n",
+      "2024-04-19 14:05:30,616|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:05:30,616|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:05:30,616|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:06:31,625|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:06:31,625|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:06:31,625|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:07:34,056|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:07:34,056|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:07:34,056|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:08:35,029|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:08:35,029|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:08:35,029|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:09:36,047|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:09:36,047|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:09:36,047|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:10:39,742|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:10:39,742|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:10:39,742|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:11:40,658|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:11:40,658|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:11:40,658|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:12:41,485|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:12:41,485|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:12:41,485|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is running (on backend cdse).\n",
+      "2024-04-19 14:13:42,829|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is finished (on backend cdse).\n",
+      "2024-04-19 14:13:42,829|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is finished (on backend cdse).\n",
+      "2024-04-19 14:13:42,829|openeo_gfmap.manager|DEBUG:  Status of job j-2404199f90ea41e1bced31bf1d690dfb is finished (on backend cdse).\n",
+      "2024-04-19 14:13:42,834|openeo_gfmap.manager|INFO:  Job j-2404199f90ea41e1bced31bf1d690dfb finished successfully, queueing on_job_done...\n",
+      "2024-04-19 14:13:42,834|openeo_gfmap.manager|INFO:  Job j-2404199f90ea41e1bced31bf1d690dfb finished successfully, queueing on_job_done...\n",
+      "2024-04-19 14:13:42,834|openeo_gfmap.manager|INFO:  Job j-2404199f90ea41e1bced31bf1d690dfb finished successfully, queueing on_job_done...\n",
+      "2024-04-19 14:13:54,577|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404199f90ea41e1bced31bf1d690dfb...\n",
+      "2024-04-19 14:13:54,577|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404199f90ea41e1bced31bf1d690dfb...\n",
+      "2024-04-19 14:13:54,577|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404199f90ea41e1bced31bf1d690dfb...\n",
+      "2024-04-19 14:14:12,490|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404199f90ea41e1bced31bf1d690dfb -> /data/users/Public/vincent.verelst/world_cereal/test_load_stac/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2194075736/S2-L2A-10m_2021_BE_Flanders_full_2194075736_32631_2020-08-30_2022-03-03.nc\n",
+      "2024-04-19 14:14:12,490|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404199f90ea41e1bced31bf1d690dfb -> /data/users/Public/vincent.verelst/world_cereal/test_load_stac/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2194075736/S2-L2A-10m_2021_BE_Flanders_full_2194075736_32631_2020-08-30_2022-03-03.nc\n",
+      "2024-04-19 14:14:12,490|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404199f90ea41e1bced31bf1d690dfb -> /data/users/Public/vincent.verelst/world_cereal/test_load_stac/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2194075736/S2-L2A-10m_2021_BE_Flanders_full_2194075736_32631_2020-08-30_2022-03-03.nc\n",
+      "2024-04-19 14:14:25,099|openeo_gfmap.manager|INFO:  Parsed item openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404199f90ea41e1bced31bf1d690dfb\n",
+      "2024-04-19 14:14:25,099|openeo_gfmap.manager|INFO:  Parsed item openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404199f90ea41e1bced31bf1d690dfb\n",
+      "2024-04-19 14:14:25,099|openeo_gfmap.manager|INFO:  Parsed item openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404199f90ea41e1bced31bf1d690dfb\n",
+      "2024-04-19 14:14:25,103|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404199f90ea41e1bced31bf1d690dfb...\n",
+      "2024-04-19 14:14:25,103|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404199f90ea41e1bced31bf1d690dfb...\n",
+      "2024-04-19 14:14:25,103|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404199f90ea41e1bced31bf1d690dfb...\n",
+      "2024-04-19 14:14:31,871|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
+      "2024-04-19 14:14:31,871|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
+      "2024-04-19 14:14:31,871|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
+      "2024-04-19 14:14:31,875|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
+      "2024-04-19 14:14:31,875|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
+      "2024-04-19 14:14:31,875|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
+      "2024-04-19 14:14:31,879|openeo_gfmap.manager|INFO:  Job j-2404199f90ea41e1bced31bf1d690dfb and post job action finished successfully.\n",
+      "2024-04-19 14:14:31,879|openeo_gfmap.manager|INFO:  Job j-2404199f90ea41e1bced31bf1d690dfb and post job action finished successfully.\n",
+      "2024-04-19 14:14:31,879|openeo_gfmap.manager|INFO:  Job j-2404199f90ea41e1bced31bf1d690dfb and post job action finished successfully.\n"
      ]
     }
    ],

--- a/examples/extraction_pipelines/S2_extraction_example.ipynb
+++ b/examples/extraction_pipelines/S2_extraction_example.ipynb
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -489,7 +489,7 @@
        "[222 rows x 8 columns]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,32 +533,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Run a subset of the jobs to test the manager, the selected jobs have a fair amount of geometries to extract\n",
     "# 8, 6, 4, 2 and 1 tiles\n",
-    "job_df = job_df.iloc[[2]]#.reset_index(drop=True)"
+    "job_df = job_df.iloc[[2]].reset_index(drop=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_196063/67342996.py:7: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  job_df['nb_polygons'] = job_df.apply(get_job_nb_polygons, axis=1)\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -593,7 +581,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>0</th>\n",
        "      <td>cdse</td>\n",
        "      <td>S2-L2A-10m</td>\n",
        "      <td>.nc</td>\n",
@@ -610,16 +598,16 @@
       ],
       "text/plain": [
        "  backend_name  out_prefix out_extension  start_date    end_date s2_tile  \\\n",
-       "2         cdse  S2-L2A-10m           .nc  2020-08-30  2022-03-03   31UES   \n",
+       "0         cdse  S2-L2A-10m           .nc  2020-08-30  2022-03-03   31UES   \n",
        "\n",
        "           h3index                                           geometry  \\\n",
-       "2  83194dfffffffff  {\"type\": \"FeatureCollection\", \"features\": [{\"i...   \n",
+       "0  83194dfffffffff  {\"type\": \"FeatureCollection\", \"features\": [{\"i...   \n",
        "\n",
        "   nb_polygons  \n",
-       "2            1  "
+       "0            1  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -651,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,7 +799,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -823,7 +811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -864,7 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1004,25 +992,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1032,7 +1011,7 @@
     "\n",
     "\n",
     "base_output_dir = Path('/data/users/Public/vincent.verelst/world_cereal/extractions_april/')\n",
-    "tracking_job_csv = base_output_dir / 'job_tracker.csv'\n",
+    "tracking_job_csv = base_output_dir / 'job_tracker2.csv'\n",
     "stac = '/data/users/Public/vincent.verelst/world_cereal/extractions_april/stac/collection.json'\n",
     "\n",
     "manager = GFMAPJobManager(\n",
@@ -1052,25 +1031,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-04-16 14:27:06,680|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
-      "2024-04-16 14:27:06,681|openeo_gfmap.manager|INFO:  Creating and running jobs.\n"
+      "2024-04-18 11:07:24,241|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
+      "2024-04-18 11:07:24,242|openeo_gfmap.manager|INFO:  Creating and running jobs.\n",
+      "2024-04-18 11:07:24,273|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
+      "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
+      "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
+      "      dtype='object')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Authenticated using refresh token.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-04-16 14:27:06,840|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
-      "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
-      "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
-      "      dtype='object')\n"
+      "/home/vverelst/anaconda3/envs/openeo-gfmap/lib/python3.9/site-packages/openeo/rest/connection.py:1189: UserWarning: SENTINEL2_L2A property filtering with properties that are undefined in the collection metadata (summaries): tileId.\n",
+      "  return DataCube.load_collection(\n",
+      "2024-04-18 11:07:27,498|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
+      "2024-04-18 11:08:48,684|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
+      "2024-04-18 11:09:49,505|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
+      "2024-04-18 11:10:59,552|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
+      "2024-04-18 11:12:00,162|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
+      "2024-04-18 11:13:00,796|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
+      "2024-04-18 11:14:01,330|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
+      "2024-04-18 11:15:01,932|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
+      "2024-04-18 11:16:03,458|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
+      "2024-04-18 11:17:04,204|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is finished (on backend cdse).\n",
+      "2024-04-18 11:17:04,206|openeo_gfmap.manager|INFO:  Job j-2404188140bf4b8e9ab3c7a2d55926d3 finished successfully, queueing on_job_done...\n",
+      "2024-04-18 11:17:09,315|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404188140bf4b8e9ab3c7a2d55926d3...\n",
+      "2024-04-18 11:17:20,486|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404188140bf4b8e9ab3c7a2d55926d3 -> /data/users/Public/vincent.verelst/world_cereal/extractions_april/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2194075736/S2-L2A-10m_2021_BE_Flanders_full_2194075736_32631_2020-08-30_2022-03-03.nc\n",
+      "2024-04-18 11:17:23,163|openeo_gfmap.manager|INFO:  Parsed item openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404188140bf4b8e9ab3c7a2d55926d3\n",
+      "2024-04-18 11:17:23,164|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404188140bf4b8e9ab3c7a2d55926d3...\n",
+      "2024-04-18 11:17:28,664|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
+      "2024-04-18 11:17:28,831|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
+      "2024-04-18 11:17:28,832|openeo_gfmap.manager|INFO:  Job j-2404188140bf4b8e9ab3c7a2d55926d3 and post job action finished successfully.\n"
      ]
     }
    ],

--- a/examples/extraction_pipelines/S2_extraction_example.ipynb
+++ b/examples/extraction_pipelines/S2_extraction_example.ipynb
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -489,7 +489,7 @@
        "[222 rows x 8 columns]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,20 +533,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Run a subset of the jobs to test the manager, the selected jobs have a fair amount of geometries to extract\n",
     "# 8, 6, 4, 2 and 1 tiles\n",
-    "job_df = job_df.iloc[[0]].reset_index(drop=True)"
+    "job_df = job_df.iloc[[2]]#.reset_index(drop=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_196063/67342996.py:7: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  job_df['nb_polygons'] = job_df.apply(get_job_nb_polygons, axis=1)\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -581,13 +593,13 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
+       "      <th>2</th>\n",
        "      <td>cdse</td>\n",
        "      <td>S2-L2A-10m</td>\n",
        "      <td>.nc</td>\n",
        "      <td>2020-08-30</td>\n",
        "      <td>2022-03-03</td>\n",
-       "      <td>31UDS</td>\n",
+       "      <td>31UES</td>\n",
        "      <td>83194dfffffffff</td>\n",
        "      <td>{\"type\": \"FeatureCollection\", \"features\": [{\"i...</td>\n",
        "      <td>1</td>\n",
@@ -598,16 +610,16 @@
       ],
       "text/plain": [
        "  backend_name  out_prefix out_extension  start_date    end_date s2_tile  \\\n",
-       "0         cdse  S2-L2A-10m           .nc  2020-08-30  2022-03-03   31UDS   \n",
+       "2         cdse  S2-L2A-10m           .nc  2020-08-30  2022-03-03   31UES   \n",
        "\n",
        "           h3index                                           geometry  \\\n",
-       "0  83194dfffffffff  {\"type\": \"FeatureCollection\", \"features\": [{\"i...   \n",
+       "2  83194dfffffffff  {\"type\": \"FeatureCollection\", \"features\": [{\"i...   \n",
        "\n",
        "   nb_polygons  \n",
-       "0            1  "
+       "2            1  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -639,7 +651,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -865,7 +877,6 @@
     "from shapely.geometry import box\n",
     "from rasterio.features import rasterize\n",
     "from rasterio.transform import from_bounds\n",
-    "# from openeo_gfmap.stac import AUXILIARY\n",
     "from openeo_gfmap.utils import update_nc_attributes\n",
     "\n",
     "def add_item_asset(related_item: pystac.Item, path: Path):\n",
@@ -904,8 +915,6 @@
     "\n",
     "        update_nc_attributes(item_asset_path, new_attributes)\n",
     "        \n",
-    "        # # Read information from the item file\n",
-    "        # result_ds = xr.open_dataset(item_asset_path)\n",
     "\n",
     "        target_crs = CRS.from_epsg(list(item.assets.values())[0].extra_fields['proj:epsg'])\n",
     "\n",
@@ -995,16 +1004,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1015,14 +1033,12 @@
     "\n",
     "base_output_dir = Path('/data/users/Public/vincent.verelst/world_cereal/extractions_april/')\n",
     "tracking_job_csv = base_output_dir / 'job_tracker.csv'\n",
+    "stac = '/data/users/Public/vincent.verelst/world_cereal/extractions_april/stac/collection.json'\n",
     "\n",
     "manager = GFMAPJobManager(\n",
     "    output_dir=base_output_dir,\n",
     "    output_path_generator=generate_output_path_s2,\n",
-    "    collection_id='SENTINEL2-EXTRACTION',\n",
-    "    collection_description=(\n",
-    "        \"Sentinel-2 and Auxiliary data extraction example.\"\n",
-    "    ),\n",
+    "    stac=stac,\n",
     "    post_job_action=post_job_action,\n",
     "    poll_sleep=60,\n",
     "    n_threads=2,\n",
@@ -1036,50 +1052,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-04-15 17:37:41,059|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
-      "2024-04-15 17:37:41,060|openeo_gfmap.manager|INFO:  Creating and running jobs.\n",
-      "2024-04-15 17:37:41,253|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
-      "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
-      "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
-      "      dtype='object')\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Authenticated using refresh token.\n"
+      "2024-04-16 14:27:06,680|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
+      "2024-04-16 14:27:06,681|openeo_gfmap.manager|INFO:  Creating and running jobs.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/vverelst/anaconda3/envs/openeo-gfmap/lib/python3.9/site-packages/openeo/rest/connection.py:1189: UserWarning: SENTINEL2_L2A property filtering with properties that are undefined in the collection metadata (summaries): tileId.\n",
-      "  return DataCube.load_collection(\n",
-      "2024-04-15 17:37:45,235|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
-      "2024-04-15 17:39:06,144|openeo_gfmap.manager|DEBUG:  Status of job j-2404158f9f46404d9a1bd244b49b171b is running (on backend cdse).\n",
-      "2024-04-15 17:40:06,769|openeo_gfmap.manager|DEBUG:  Status of job j-2404158f9f46404d9a1bd244b49b171b is running (on backend cdse).\n",
-      "2024-04-15 17:41:07,498|openeo_gfmap.manager|DEBUG:  Status of job j-2404158f9f46404d9a1bd244b49b171b is running (on backend cdse).\n",
-      "2024-04-15 17:42:08,317|openeo_gfmap.manager|DEBUG:  Status of job j-2404158f9f46404d9a1bd244b49b171b is running (on backend cdse).\n",
-      "2024-04-15 17:43:09,048|openeo_gfmap.manager|DEBUG:  Status of job j-2404158f9f46404d9a1bd244b49b171b is running (on backend cdse).\n",
-      "2024-04-15 17:44:11,711|openeo_gfmap.manager|DEBUG:  Status of job j-2404158f9f46404d9a1bd244b49b171b is running (on backend cdse).\n",
-      "2024-04-15 17:45:12,325|openeo_gfmap.manager|DEBUG:  Status of job j-2404158f9f46404d9a1bd244b49b171b is finished (on backend cdse).\n",
-      "2024-04-15 17:45:12,327|openeo_gfmap.manager|INFO:  Job j-2404158f9f46404d9a1bd244b49b171b finished successfully, queueing on_job_done...\n",
-      "2024-04-15 17:45:14,065|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_936816805.nc from job j-2404158f9f46404d9a1bd244b49b171b...\n",
-      "2024-04-15 17:45:25,700|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_936816805.nc from job j-2404158f9f46404d9a1bd244b49b171b -> /data/users/Public/vincent.verelst/world_cereal/extractions_april/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2195082011/S2-L2A-10m_2021_BE_Flanders_full_2195082011_32631_2020-08-30_2022-03-03.nc\n",
-      "2024-04-15 17:45:27,573|openeo_gfmap.manager|INFO:  Parsed item j-2404158f9f46404d9a1bd244b49b171b_openEO_2021_BE_Flanders_full_936816805.nc from job j-2404158f9f46404d9a1bd244b49b171b\n",
-      "2024-04-15 17:45:27,575|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404158f9f46404d9a1bd244b49b171b...\n",
-      "2024-04-15 17:45:32,206|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
-      "2024-04-15 17:45:32,209|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
-      "2024-04-15 17:45:32,210|openeo_gfmap.manager|INFO:  Job j-2404158f9f46404d9a1bd244b49b171b and post job action finished successfully.\n"
+      "2024-04-16 14:27:06,840|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
+      "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
+      "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
+      "      dtype='object')\n"
      ]
     }
    ],
@@ -1090,6 +1081,13 @@
     "# In the post job actions, an extra 'auxiliary' asset was added to each item. The asset definition is therefore also added to the item_asset_definitions extensions of the final STAC collection\n",
     "manager.create_stac(constellation='sentinel2', item_assets=item_assets)  # By default the STAC catalogue will be saved in the stac subfolder of the base_output_dir folder."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/extraction_pipelines/S2_extraction_example.ipynb
+++ b/examples/extraction_pipelines/S2_extraction_example.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -235,7 +235,13 @@
       "  geom_col = polygons.geometry.centroid\n",
       "/home/vverelst/openeo/openeo-gfmap/src/openeo_gfmap/manager/job_splitters.py:60: UserWarning: Geometry is in a geographic CRS. Results from 'centroid' are likely incorrect. Use 'GeoSeries.to_crs()' to re-project geometries to a projected CRS before this operation.\n",
       "\n",
-      "  polygons[\"geometry\"] = polygons.geometry.centroid\n"
+      "  polygons[\"geometry\"] = polygons.geometry.centroid\n",
+      "/home/vverelst/openeo/openeo-gfmap/src/openeo_gfmap/manager/job_splitters.py:64: UserWarning: Geometry is in a geographic CRS. Results from 'centroid' are likely incorrect. Use 'GeoSeries.to_crs()' to re-project geometries to a projected CRS before this operation.\n",
+      "\n",
+      "  s2_grid[\"geometry\"] = s2_grid.geometry.centroid\n",
+      "/home/vverelst/anaconda3/envs/openeo-gfmap/lib/python3.9/site-packages/geopandas/array.py:365: UserWarning: Geometry is in a geographic CRS. Results from 'sjoin_nearest' are likely incorrect. Use 'GeoSeries.to_crs()' to re-project geometries to a projected CRS before this operation.\n",
+      "\n",
+      "  warnings.warn(\n"
      ]
     },
     {
@@ -244,18 +250,6 @@
      "text": [
       "270 sub-datasets.\n",
       "222 sub-datasets after filtering sub-datasets with no point to extract.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/vverelst/openeo/openeo-gfmap/src/openeo_gfmap/manager/job_splitters.py:64: UserWarning: Geometry is in a geographic CRS. Results from 'centroid' are likely incorrect. Use 'GeoSeries.to_crs()' to re-project geometries to a projected CRS before this operation.\n",
-      "\n",
-      "  s2_grid[\"geometry\"] = s2_grid.geometry.centroid\n",
-      "/home/vverelst/anaconda3/envs/openeo-gfmap/lib/python3.9/site-packages/geopandas/array.py:365: UserWarning: Geometry is in a geographic CRS. Results from 'sjoin_nearest' are likely incorrect. Use 'GeoSeries.to_crs()' to re-project geometries to a projected CRS before this operation.\n",
-      "\n",
-      "  warnings.warn(\n"
      ]
     }
    ],
@@ -298,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -489,7 +483,7 @@
        "[222 rows x 8 columns]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +538,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -607,7 +601,7 @@
        "0            1  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -639,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,7 +805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -952,17 +946,28 @@
     "        x_coords = np.arange(item.properties['proj:bbox'][0], item.properties['proj:bbox'][2], 10) + 5\n",
     "        y_coords = np.arange(item.properties['proj:bbox'][1], item.properties['proj:bbox'][3], 10) + 5\n",
     "\n",
+    "        label = xr.DataArray(croptype, \n",
+    "            dims=['y', 'x'],\n",
+    "            coords={'x': x_coords, 'y': y_coords}, \n",
+    "            name='LABEL',\n",
+    "            attrs={'grid_mapping': 'crs', '_FillValue': fill_value})\n",
+    "        \n",
+    "        label.coords['x'].attrs = {'units': 'm', 'long_name': 'x coordinate of projection', 'standard_name': 'projection_x_coordinate'}\n",
+    "        label.coords['y'].attrs = {'units': 'm', 'long_name': 'y coordinate of projection', 'standard_name': 'projection_y_coordinate'}\n",
+    "\n",
     "        aux_dataset = xr.Dataset(\n",
-    "            {'LABEL': (('y', 'x'), croptype)},\n",
-    "            coords={'y': y_coords, 'x': x_coords},\n",
+    "            coords={'x': x_coords, 'y': y_coords},\n",
     "            attrs=attributes\n",
     "        )\n",
+    "        \n",
     "        aux_dataset = aux_dataset.assign(crs=b'')\n",
     "        aux_dataset['crs'].attrs['crs_wkt'] = target_crs.to_wkt()\n",
     "        aux_dataset['crs'].attrs['spatial_ref'] = target_crs.to_wkt()\n",
     "\n",
+    "        aux_dataset['LABEL'] = label\n",
+    "\n",
     "        # Required to map the 'crs' layer as geo-reference for the 'LABEL' layer.\n",
-    "        aux_dataset['LABEL'].attrs['grid_mapping'] = 'crs'\n",
+    "        # aux_dataset['LABEL'].attrs['grid_mapping'] = 'crs'\n",
     "\n",
     "        # Save the metadata in the same folder as the S2 product\n",
     "        metadata_path = (\n",
@@ -970,7 +975,7 @@
     "            f'WORLDCEREAL_10m_{sample_id}_{target_crs.to_epsg()}_{valid_date}.nc'\n",
     "        )\n",
     "\n",
-    "        aux_dataset.to_netcdf(metadata_path, format='NETCDF4', engine='h5netcdf')\n",
+    "        aux_dataset.to_netcdf(metadata_path, format='NETCDF4')\n",
     "        aux_dataset.close()\n",
     "\n",
     "        # Adds this metadata as a new asset\n",
@@ -992,16 +997,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1010,14 +1024,15 @@
     "from openeo_gfmap.backend import cdse_connection\n",
     "\n",
     "\n",
-    "base_output_dir = Path('/data/users/Public/vincent.verelst/world_cereal/extractions_april/')\n",
-    "tracking_job_csv = base_output_dir / 'job_tracker2.csv'\n",
+    "base_output_dir = Path('/data/users/Public/vincent.verelst/world_cereal/test_load_stac/')\n",
+    "tracking_job_csv = base_output_dir / 'job_tracker.csv'\n",
     "stac = '/data/users/Public/vincent.verelst/world_cereal/extractions_april/stac/collection.json'\n",
     "\n",
     "manager = GFMAPJobManager(\n",
     "    output_dir=base_output_dir,\n",
     "    output_path_generator=generate_output_path_s2,\n",
-    "    stac=stac,\n",
+    "    collection_id=\"SENTINEL2_L2A\",\n",
+    "    # stac=stac,\n",
     "    post_job_action=post_job_action,\n",
     "    poll_sleep=60,\n",
     "    n_threads=2,\n",
@@ -1031,16 +1046,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-04-18 11:07:24,241|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
-      "2024-04-18 11:07:24,242|openeo_gfmap.manager|INFO:  Creating and running jobs.\n",
-      "2024-04-18 11:07:24,273|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
+      "2024-04-19 13:09:53,046|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
+      "2024-04-19 13:09:53,046|openeo_gfmap.manager|INFO:  Starting ThreadPoolExecutor with 2 workers.\n",
+      "2024-04-19 13:09:53,048|openeo_gfmap.manager|INFO:  Creating and running jobs.\n",
+      "2024-04-19 13:09:53,048|openeo_gfmap.manager|INFO:  Creating and running jobs.\n",
+      "2024-04-19 13:09:53,203|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
+      "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
+      "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
+      "      dtype='object')\n",
+      "2024-04-19 13:09:53,203|openeo_gfmap.manager|DEBUG:  Normalizing dataframe. Columns: Index(['backend_name', 'out_prefix', 'out_extension', 'start_date', 'end_date',\n",
       "       's2_tile', 'h3index', 'geometry', 'nb_polygons', 'status', 'id',\n",
       "       'start_time', 'cpu', 'memory', 'duration', 'description', 'costs'],\n",
       "      dtype='object')\n"
@@ -1059,24 +1080,40 @@
      "text": [
       "/home/vverelst/anaconda3/envs/openeo-gfmap/lib/python3.9/site-packages/openeo/rest/connection.py:1189: UserWarning: SENTINEL2_L2A property filtering with properties that are undefined in the collection metadata (summaries): tileId.\n",
       "  return DataCube.load_collection(\n",
-      "2024-04-18 11:07:27,498|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
-      "2024-04-18 11:08:48,684|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
-      "2024-04-18 11:09:49,505|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
-      "2024-04-18 11:10:59,552|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
-      "2024-04-18 11:12:00,162|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
-      "2024-04-18 11:13:00,796|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
-      "2024-04-18 11:14:01,330|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
-      "2024-04-18 11:15:01,932|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
-      "2024-04-18 11:16:03,458|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is running (on backend cdse).\n",
-      "2024-04-18 11:17:04,204|openeo_gfmap.manager|DEBUG:  Status of job j-2404188140bf4b8e9ab3c7a2d55926d3 is finished (on backend cdse).\n",
-      "2024-04-18 11:17:04,206|openeo_gfmap.manager|INFO:  Job j-2404188140bf4b8e9ab3c7a2d55926d3 finished successfully, queueing on_job_done...\n",
-      "2024-04-18 11:17:09,315|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404188140bf4b8e9ab3c7a2d55926d3...\n",
-      "2024-04-18 11:17:20,486|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404188140bf4b8e9ab3c7a2d55926d3 -> /data/users/Public/vincent.verelst/world_cereal/extractions_april/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2194075736/S2-L2A-10m_2021_BE_Flanders_full_2194075736_32631_2020-08-30_2022-03-03.nc\n",
-      "2024-04-18 11:17:23,163|openeo_gfmap.manager|INFO:  Parsed item openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404188140bf4b8e9ab3c7a2d55926d3\n",
-      "2024-04-18 11:17:23,164|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404188140bf4b8e9ab3c7a2d55926d3...\n",
-      "2024-04-18 11:17:28,664|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
-      "2024-04-18 11:17:28,831|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
-      "2024-04-18 11:17:28,832|openeo_gfmap.manager|INFO:  Job j-2404188140bf4b8e9ab3c7a2d55926d3 and post job action finished successfully.\n"
+      "2024-04-19 13:09:55,512|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
+      "2024-04-19 13:09:55,512|openeo_gfmap.manager|DEBUG:  Number of polygons to extract: 1\n",
+      "2024-04-19 13:11:39,648|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:11:39,648|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:12:40,465|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:12:40,465|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:13:41,391|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:13:41,391|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:14:42,226|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:14:42,226|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:15:43,350|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:15:43,350|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:16:44,219|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:16:44,219|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:17:45,007|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:17:45,007|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is running (on backend cdse).\n",
+      "2024-04-19 13:18:46,035|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is finished (on backend cdse).\n",
+      "2024-04-19 13:18:46,035|openeo_gfmap.manager|DEBUG:  Status of job j-2404196e403346cfa2a098dd008cb329 is finished (on backend cdse).\n",
+      "2024-04-19 13:18:46,038|openeo_gfmap.manager|INFO:  Job j-2404196e403346cfa2a098dd008cb329 finished successfully, queueing on_job_done...\n",
+      "2024-04-19 13:18:46,038|openeo_gfmap.manager|INFO:  Job j-2404196e403346cfa2a098dd008cb329 finished successfully, queueing on_job_done...\n",
+      "2024-04-19 13:18:47,389|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329...\n",
+      "2024-04-19 13:18:47,389|openeo_gfmap.manager|DEBUG:  Generating output path for asset openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329...\n",
+      "2024-04-19 13:19:03,634|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329 -> /data/users/Public/vincent.verelst/world_cereal/test_load_stac/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2194075736/S2-L2A-10m_2021_BE_Flanders_full_2194075736_32631_2020-08-30_2022-03-03.nc\n",
+      "2024-04-19 13:19:03,634|openeo_gfmap.manager|DEBUG:  Downloaded openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329 -> /data/users/Public/vincent.verelst/world_cereal/test_load_stac/2021_EUR_DEMO_POLY_110/83194dfffffffff/2021_BE_Flanders_full_2194075736/S2-L2A-10m_2021_BE_Flanders_full_2194075736_32631_2020-08-30_2022-03-03.nc\n",
+      "2024-04-19 13:19:07,115|openeo_gfmap.manager|INFO:  Parsed item openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329\n",
+      "2024-04-19 13:19:07,115|openeo_gfmap.manager|INFO:  Parsed item openEO_2021_BE_Flanders_full_1971166096.nc from job j-2404196e403346cfa2a098dd008cb329\n",
+      "2024-04-19 13:19:07,118|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404196e403346cfa2a098dd008cb329...\n",
+      "2024-04-19 13:19:07,118|openeo_gfmap.manager|DEBUG:  Calling post job action for job j-2404196e403346cfa2a098dd008cb329...\n",
+      "2024-04-19 13:19:12,145|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
+      "2024-04-19 13:19:12,145|openeo_gfmap.manager|INFO:  Adding 1 items to the STAC collection...\n",
+      "2024-04-19 13:19:12,149|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
+      "2024-04-19 13:19:12,149|openeo_gfmap.manager|INFO:  Added 1 items to the STAC collection.\n",
+      "2024-04-19 13:19:12,151|openeo_gfmap.manager|INFO:  Job j-2404196e403346cfa2a098dd008cb329 and post job action finished successfully.\n",
+      "2024-04-19 13:19:12,151|openeo_gfmap.manager|INFO:  Job j-2404196e403346cfa2a098dd008cb329 and post job action finished successfully.\n"
      ]
     }
    ],

--- a/src/openeo_gfmap/manager/job_manager.py
+++ b/src/openeo_gfmap/manager/job_manager.py
@@ -59,9 +59,18 @@ class GFMAPJobManager(MultiBackendJobManager):
         self._root_collection = self._normalize_stac()
 
     def _normalize_stac(self):
+        default_collection_path = self._output_dir / "stac/collection.json"
         if self.stac is not None:
+            _log.info(f"Reloading the STAC collection from the provided path: {self.stac}.")
+            root_collection = pystac.read_file(str(self.stac))
+        elif default_collection_path.exists():
+            _log.info(
+                f"Reload the STAC collection from the default path: {default_collection_path}."
+            )
+            self.stac = default_collection_path
             root_collection = pystac.read_file(str(self.stac))
         else:
+            _log.info("Starting a fresh STAC collection.")
             assert (
                 self.collection_id is not None
             ), "A collection ID is required to generate a STAC collection."

--- a/src/openeo_gfmap/manager/job_manager.py
+++ b/src/openeo_gfmap/manager/job_manager.py
@@ -30,7 +30,7 @@ class GFMAPJobManager(MultiBackendJobManager):
         output_path_generator: Callable,
         collection_id: Optional[str] = None,
         collection_description: Optional[str] = "",
-        stac : Optional[Union[str, Path]] = None,
+        stac: Optional[Union[str, Path]] = None,
         post_job_action: Optional[Callable] = None,
         poll_sleep: int = 5,
         n_threads: int = 1,
@@ -62,7 +62,9 @@ class GFMAPJobManager(MultiBackendJobManager):
         if self.stac is not None:
             root_collection = pystac.read_file(str(self.stac))
         else:
-            assert self.collection_id is not None, "A collection ID is required to generate a STAC collection."
+            assert (
+                self.collection_id is not None
+            ), "A collection ID is required to generate a STAC collection."
             root_collection = pystac.Collection(
                 id=self.collection_id,
                 description=self.collection_description,
@@ -71,9 +73,9 @@ class GFMAPJobManager(MultiBackendJobManager):
             root_collection.license = constants.LICENSE
             root_collection.add_link(constants.LICENSE_LINK)
             root_collection.stac_extensions = constants.STAC_EXTENSIONS
-        
+
         return root_collection
-    
+
     def _update_statuses(self, df: pd.DataFrame):
         """Updates the statues of the jobs in the dataframe from the backend. If a job is finished
         or failed, it will be queued to the `on_job_done` or `on_job_error` methods.
@@ -294,12 +296,12 @@ class GFMAPJobManager(MultiBackendJobManager):
         if output_path is None:
             output_path = self._output_dir / "stac"
 
-        if not "summaries" in self._root_collection.extra_fields:
+        if "summaries" not in self._root_collection.extra_fields:
             self._root_collection.extra_fields["summaries"] = constants.SUMMARIES.get(
                 constellation, pystac.summaries.Summaries({})
             ).to_dict()
 
-        if item_assets and not 'item_assets' in self._root_collection.extra_fields:
+        if item_assets and "item_assets" not in self._root_collection.extra_fields:
             item_asset_extension = pystac.extensions.item_assets.ItemAssetsExtension.ext(
                 self._root_collection, add_if_missing=True
             )


### PR DESCRIPTION
- For now a user has to provide the location of the STAC collection they want to extend. Possible to later add a feature that automatically searches for an existing STAC collection
- The user also has to make sure they use a different job_tracker than the one already existing, otherwise new jobs will not be run. This is logged here: https://github.com/Open-EO/openeo-python-client/issues/558
- Also updated the metadata of the ground truth dataset, such that it can be read by `load_stac` in openeo