### PR TITLE
S1 extraction fixes

### DIFF
--- a/src/openeo_gfmap/fetching/generic.py
+++ b/src/openeo_gfmap/fetching/generic.py
@@ -117,6 +117,10 @@ OTHER_BACKEND_MAP = {
             "fetch": partial(_get_generic_fetcher, collection_name="AGERA5"),
             "preprocessor": partial(_get_generic_processor, collection_name="AGERA5"),
         },
+        Backend.CDSE_STAGING: {
+            "fetch": partial(_get_generic_fetcher, collection_name="AGERA5"),
+            "preprocessor": partial(_get_generic_processor, collection_name="AGERA5"),
+        },
         Backend.FED: {
             "fetch": partial(_get_generic_fetcher, collection_name="AGERA5"),
             "preprocessor": partial(_get_generic_processor, collection_name="AGERA5"),
@@ -130,6 +134,12 @@ OTHER_BACKEND_MAP = {
             ),
         },
         Backend.CDSE: {
+            "fetch": partial(_get_generic_fetcher, collection_name="COPERNICUS_30"),
+            "preprocessor": partial(
+                _get_generic_processor, collection_name="COPERNICUS_30"
+            ),
+        },
+        Backend.CDSE_STAGING: {
             "fetch": partial(_get_generic_fetcher, collection_name="COPERNICUS_30"),
             "preprocessor": partial(
                 _get_generic_processor, collection_name="COPERNICUS_30"

--- a/src/openeo_gfmap/fetching/s1.py
+++ b/src/openeo_gfmap/fetching/s1.py
@@ -67,8 +67,6 @@ def _get_s1_grd_default_fetcher(
         """
         bands = convert_band_names(bands, BASE_SENTINEL1_GRD_MAPPING)
 
-        load_collection_parameters = params.get("load_collection", {})
-
         cube = _load_collection(
             connection,
             bands,
@@ -76,7 +74,7 @@ def _get_s1_grd_default_fetcher(
             spatial_extent,
             temporal_extent,
             fetch_type,
-            **load_collection_parameters,
+            **params,
         )
 
         if fetch_type is not FetchType.POINT and isinstance(spatial_extent, GeoJSON):

--- a/src/openeo_gfmap/manager/job_splitters.py
+++ b/src/openeo_gfmap/manager/job_splitters.py
@@ -61,7 +61,7 @@ def split_job_s2grid(
         raise ValueError("The GeoDataFrame must contain a CRS")
 
     polygons = polygons.to_crs(epsg=4326)
-    if polygons.geometry.geom_type[0] != "Point":
+    if polygons.geometry.iloc[0].geom_type[0] != "Point":
         polygons["geometry"] = polygons.geometry.centroid
 
     # Dataset containing all the S2 tiles, find the nearest S2 tile for each point

--- a/src/openeo_gfmap/utils/catalogue.py
+++ b/src/openeo_gfmap/utils/catalogue.py
@@ -1,9 +1,12 @@
 """Functionalities to interract with product catalogues."""
 
+from typing import Optional
+
 import requests
 from geojson import GeoJSON
 from pyproj.crs import CRS
 from rasterio.warp import transform_bounds
+from requests import adapters
 from shapely import unary_union
 from shapely.geometry import box, shape
 
@@ -14,6 +17,20 @@ from openeo_gfmap import (
     SpatialContext,
     TemporalContext,
 )
+
+request_sessions: Optional[requests.Session] = None
+
+
+def _request_session() -> requests.Session:
+    global request_sessions
+
+    if request_sessions is None:
+        request_sessions = requests.Session()
+        retries = adapters.Retry(
+            total=5, backoff_factor=1, status_forcelist=[500, 502, 503, 504]
+        )
+        request_sessions.mount("https://", adapters.HTTPAdapter(max_retries=retries))
+    return request_sessions
 
 
 class UncoveredS1Exception(Exception):
@@ -48,13 +65,14 @@ def _query_cdse_catalogue(
     url = (
         f"https://catalogue.dataspace.copernicus.eu/resto/api/collections/"
         f"{collection}/search.json?box={minx},{miny},{maxx},{maxy}"
-        f"&sortParam=startDate&maxRecords=100"
+        f"&sortParam=startDate&maxRecords=1000&polarisation=VV%26VH"
         f"&dataset=ESA-DATASET&startDate={start_date}&completionDate={end_date}"
     )
     for key, value in additional_parameters.items():
         url += f"&{key}={value}"
 
-    response = requests.get(url)
+    session = _request_session()
+    response = session.get(url, timeout=60)
 
     if response.status_code != 200:
         raise Exception(


### PR DESCRIPTION
I add some fixes that were requirement for my sentinel-1 extraction pipeline

- Fix in the S1 fetcher where "load_collection" parameters were incorrectly parsed.
- Issue in `job_splitter` where geometry type wasn't correctly parsed
- Made the S1 catalogue query more robust by retrying queries on backend fails. 
- Added the polarisation to "VV&VH" in the catalogue querry. This should be parametrizable in the long term but I would keep it hardcoded for now as almost all the cases look at the following bands. 