### PR TITLE
Job splitters should retain original geometries

### DIFF
--- a/tests/test_openeo_gfmap/test_managers.py
+++ b/tests/test_openeo_gfmap/test_managers.py
@@ -2,9 +2,9 @@
 
 
 import geopandas as gpd
-from shapely.geometry import Point
+from shapely.geometry import Point, Polygon
 
-from openeo_gfmap.manager.job_splitters import split_job_s2grid
+from openeo_gfmap.manager.job_splitters import split_job_hex, split_job_s2grid
 
 
 def test_split_job_s2grid():
@@ -37,6 +37,58 @@ def test_split_job_s2grid():
         assert (
             "geometry" in gdf.columns
         ), "Each GeoDataFrame should have a geometry column."
+        assert gdf.crs == 4326, "The original CRS should be preserved."
         assert all(
             gdf.geometry.geom_type == "Point"
-        ), "All geometries should be of type Point."
+        ), "Original geometries should be preserved."
+
+
+def test_split_job_hex():
+    # Create a mock GeoDataFrame with points
+    # The points/polygons are located in three different h3 hexes of size 3
+    data = {
+        "id": [1, 2, 3, 4, 5, 6],
+        "geometry": [
+            Point(60.02, 4.57),
+            Point(58.34, 5.06),
+            Point(59.92, 3.37),
+            Point(58.85, 4.90),
+            Point(58.77, 4.87),
+            Polygon(
+                [
+                    (58.78, 4.88),
+                    (58.78, 4.86),
+                    (58.76, 4.86),
+                    (58.76, 4.88),
+                    (58.78, 4.88),
+                ]
+            ),
+        ],
+    }
+    polygons = gpd.GeoDataFrame(data, crs="EPSG:4326")
+
+    max_points = 3
+
+    result = split_job_hex(polygons, max_points)
+
+    assert (
+        len(result) == 4
+    ), "The number of GeoDataFrames returned should match the number of splits needed."
+
+    for idx, gdf in enumerate(result):
+        assert (
+            "geometry" in gdf.columns
+        ), "Each GeoDataFrame should have a geometry column."
+        assert gdf.crs == 4326, "The CRS should be preserved."
+        if idx == 1:
+            assert all(
+                gdf.geometry.geom_type == "Polygon"
+            ), "Original geometries should be preserved."
+        else:
+            assert all(
+                gdf.geometry.geom_type == "Point"
+            ), "Original geometries should be preserved."
+
+        assert (
+            len(result[0]) == 3
+        ), "The number of geometries in the first split should be 3."


### PR DESCRIPTION
@kvantricht, updated both `split_job_hex` and `split_job_s2grid` so that they now:
- Retain the CRS of the original geodataframe
- Retain the geometries of the original geodataframe
- Use Web Mercator instead of lat lon to calculate the centroids, so that the warnings are gone

Also added unit tests for both. 