### PR TITLE
iterate over asset_ids instead of asset index in GFMapJobManager.on_j…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
+- `ouput_path_generator` in `GFMapJobManager.on_job_done` now requires `sample_id` as a keyword argument
 ### Removed
 
 ### Fixed
 - Fixed bug where `s1_area_per_orbitstate_vvvh` failed for FeatureCollections containing a single point
 - Fixed bug where gfmap didn't work with the latest version of the openeo-python-client
+- 
 
 ## [0.2.0] - 2024-10-10
 

--- a/src/openeo_gfmap/manager/job_manager.py
+++ b/src/openeo_gfmap/manager/job_manager.py
@@ -420,29 +420,32 @@ class GFMAPJobManager(MultiBackendJobManager):
         """
 
         job_products = {}
-        for idx, asset in enumerate(job.get_results().get_assets()):
+        job_results = job.get_results()
+        asset_ids = [a.name for a in job_results.get_assets()]
+        for idx, asset_id in enumerate(asset_ids):
             try:
+                asset = job_results.get_asset(asset_id)
                 _log.debug(
                     "Generating output path for asset %s from job %s...",
-                    asset.name,
+                    asset_id,
                     job.job_id,
                 )
-                output_path = self._output_path_gen(self._output_dir, idx, row)
+                output_path = self._output_path_gen(self._output_dir, idx, row, asset_id)
                 # Make the output path
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 asset.download(output_path)
                 # Add to the list of downloaded products
-                job_products[f"{job.job_id}_{asset.name}"] = [output_path]
+                job_products[f"{job.job_id}_{asset_id}"] = [output_path]
                 _log.debug(
                     "Downloaded %s from job %s -> %s",
-                    asset.name,
+                    asset_id,
                     job.job_id,
                     output_path,
                 )
             except Exception as e:
                 _log.exception(
                     "Error downloading asset %s from job %s:\n%s",
-                    asset.name,
+                    asset_id,
                     job.job_id,
                     e,
                 )

--- a/src/openeo_gfmap/manager/job_manager.py
+++ b/src/openeo_gfmap/manager/job_manager.py
@@ -430,7 +430,9 @@ class GFMAPJobManager(MultiBackendJobManager):
                     asset_id,
                     job.job_id,
                 )
-                output_path = self._output_path_gen(self._output_dir, idx, row, asset_id)
+                output_path = self._output_path_gen(
+                    self._output_dir, idx, row, asset_id
+                )
                 # Make the output path
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 asset.download(output_path)


### PR DESCRIPTION
@VictorVerhaert, this is a blocking issue for the WorldCereal extractions. To summarize:
- In `GFMapJobManager.on_job_done` we looped over the asset index in the batch job metadata when downloading multiple assets from one job (which can be the case if `sample_by_feature=True`)
- This implicitly assumed that the index of an asset in the original FeatureCollection and the index of that same asset in the openEO job metadata was always the same --> dangerous! This can lead to the wrong naming of your asset file, which is the case in WorldCereal extractions right now
- I changed the loop to now iterate over asset_ids

I don't believe this is 100% backwards compatible as now the `output_path_gen` callable requires `asset_id` as a keyword argument. However, in light of the future deprecation of the `GFMapJobManager` and the fact that I don't see any other solution within the current API, I think this is justifiable. 

In case you have another suggestion, please let me know!

closes #185 