### PR TITLE
Add minimal buffer to the bbox in cases of identical lat or lon values

### DIFF
--- a/src/openeo_gfmap/utils/catalogue.py
+++ b/src/openeo_gfmap/utils/catalogue.py
@@ -212,6 +212,10 @@ def s1_area_per_orbitstate_vvvh(
         else:
             geometry = unary_union(shapely_geometries)
             bounds = geometry.bounds
+        if bounds[0] == bounds[2]:
+            bounds = (bounds[0], bounds[1], bounds[2] + 0.0001, bounds[3])
+        if bounds[1] == bounds[3]:
+            bounds = (bounds[0], bounds[1], bounds[2], bounds[3] + 0.0001)
         epsg = 4326
     elif isinstance(spatial_extent, BoundingBoxExtent):
         bounds = [


### PR DESCRIPTION
Fix the special case of multiple features being exactly on a lat or lon line, by adding minimal buffer to the identical lat or lon value right before doing the catalogue query.