### PR TITLE
created decompress_backscatter_uint16 function 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=7.4.0",
+  "requests-mock>=1.8.0",
   "matplotlib>=3.3.0",
   "xarray>=2022.3.0",
   "rioxarray>=0.13.0",

--- a/src/openeo_gfmap/preprocessing/sar.py
+++ b/src/openeo_gfmap/preprocessing/sar.py
@@ -41,3 +41,34 @@ def compress_backscatter_uint16(
 
     # Change the data type to uint16 for optimization purposes
     return cube.linear_scale_range(1, 65534, 1, 65534)
+
+
+def decompress_backscatter_uint16(
+    backend_context: BackendContext, cube: openeo.DataCube
+) -> openeo.DataCube:
+    """
+    Decompresing the bands from uint16 to their original float32 values.
+
+    Parameters
+    ----------
+    backend_context : BackendContext
+        The backend context to fetch the backend name.
+    cube : openeo.DataCube
+                The datacube to decompress the backscatter values.
+    Returns
+    -------
+    openeo.DataCube
+        The datacube with the backscatter values in their original float32 values.
+    """
+
+    cube = cube.apply_dimension(
+        dimension="bands",
+        process=lambda x: array_create(
+            [
+                power(base=10, p=(20.0 * x[0].log(base=10) - 83.0) / 10.0),
+                power(base=10, p=(20.0 * x[1].log(base=10) - 83.0) / 10.0),
+            ]
+        ),
+    )
+
+    return cube

--- a/tests/tests_unit/preprocessing/conftest.py
+++ b/tests/tests_unit/preprocessing/conftest.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+from typing import List, Optional
+
+import openeo
+import pytest
+from openeo.rest._testing import build_capabilities
+from openeo.rest.connection import Connection
+from openeo.rest.datacube import DataCube
+from openeo.testing import TestDataLoader
+
+API_URL = "https://oeo.test"
+
+DEFAULT_S1_METADATA = {
+    "cube:dimensions": {
+        "x": {"type": "spatial"},
+        "y": {"type": "spatial"},
+        "t": {"type": "temporal"},
+        "bands": {"type": "bands", "values": ["VV", "VH"]},
+    },
+    "summaries": {
+        "eo:bands": [
+            {"name": "VV"},
+            {"name": "VH"},
+        ]
+    },
+}
+
+
+@pytest.fixture
+def test_data() -> TestDataLoader:
+    return TestDataLoader(root=Path(__file__).parent / "data")
+
+
+@pytest.fixture(params=["1.0.0"])
+def api_version(request):
+    return request.param
+
+
+@pytest.fixture
+def api_capabilities() -> dict:
+    """
+    Fixture to be overridden for customizing the capabilities doc used by connection fixtures.
+    To be used as kwargs for `build_capabilities`
+    """
+    return {}
+
+
+def _setup_connection(
+    api_version, requests_mock, build_capabilities_kwargs: Optional[dict] = None
+) -> Connection:
+    requests_mock.get(
+        API_URL + "/",
+        json=build_capabilities(
+            api_version=api_version, **(build_capabilities_kwargs or {})
+        ),
+    )
+    # Alias for quick tests
+    requests_mock.get(API_URL + "/collections/S1", json=DEFAULT_S1_METADATA)
+
+    requests_mock.get(
+        API_URL + "/file_formats",
+        json={
+            "output": {
+                "GTiff": {"gis_data_types": ["raster"]},
+                "netCDF": {"gis_data_types": ["raster"]},
+                "csv": {"gis_data_types": ["table"]},
+            }
+        },
+    )
+    requests_mock.get(
+        API_URL + "/udf_runtimes",
+        json={
+            "Python": {
+                "type": "language",
+                "default": "3",
+                "versions": {"3": {"libraries": {}}},
+            },
+            "R": {
+                "type": "language",
+                "default": "4",
+                "versions": {"4": {"libraries": {}}},
+            },
+        },
+    )
+
+    return openeo.connect(API_URL)
+
+
+def setup_collection_metadata(requests_mock, cid: str, bands: List[str]):
+    """Set up mock collection metadata"""
+    requests_mock.get(
+        API_URL + f"/collections/{cid}",
+        json={
+            "cube:dimensions": {"bands": {"type": "bands", "values": bands}},
+            "summaries": {"eo:bands": [{"name": b} for b in bands]},
+        },
+    )
+
+
+@pytest.fixture
+def connection(api_version, requests_mock, api_capabilities) -> Connection:
+    """Connection fixture to a backend of given version with some image collections."""
+    return _setup_connection(
+        api_version, requests_mock, build_capabilities_kwargs=api_capabilities
+    )
+
+
+@pytest.fixture
+def con100(requests_mock, api_capabilities) -> Connection:
+    """Connection fixture to a 1.0.0 backend with some image collections."""
+    return _setup_connection(
+        "1.0.0", requests_mock, build_capabilities_kwargs=api_capabilities
+    )
+
+
+@pytest.fixture
+def s1cube(connection, api_version) -> DataCube:
+    return connection.load_collection("S1")

--- a/tests/tests_unit/preprocessing/data/compress_backscatter_uint16.json
+++ b/tests/tests_unit/preprocessing/data/compress_backscatter_uint16.json
@@ -1,0 +1,171 @@
+{
+    "loadcollection1": {
+        "process_id": "load_collection",
+        "arguments": {
+            "id": "S1",
+            "spatial_extent": null,
+            "temporal_extent": null
+        }
+    },
+    "applydimension1": {
+        "process_id": "apply_dimension",
+        "arguments": {
+            "data": {
+                "from_node": "loadcollection1"
+            },
+            "dimension": "bands",
+            "process": {
+                "process_graph": {
+                    "arrayelement1": {
+                        "process_id": "array_element",
+                        "arguments": {
+                            "data": {
+                                "from_parameter": "data"
+                            },
+                            "index": 0
+                        }
+                    },
+                    "log1": {
+                        "process_id": "log",
+                        "arguments": {
+                            "base": 10,
+                            "x": {
+                                "from_node": "arrayelement1"
+                            }
+                        }
+                    },
+                    "multiply1": {
+                        "process_id": "multiply",
+                        "arguments": {
+                            "x": 10.0,
+                            "y": {
+                                "from_node": "log1"
+                            }
+                        }
+                    },
+                    "add1": {
+                        "process_id": "add",
+                        "arguments": {
+                            "x": {
+                                "from_node": "multiply1"
+                            },
+                            "y": 83.0
+                        }
+                    },
+                    "divide1": {
+                        "process_id": "divide",
+                        "arguments": {
+                            "x": {
+                                "from_node": "add1"
+                            },
+                            "y": 20.0
+                        }
+                    },
+                    "power1": {
+                        "process_id": "power",
+                        "arguments": {
+                            "base": 10,
+                            "p": {
+                                "from_node": "divide1"
+                            }
+                        }
+                    },
+                    "arrayelement2": {
+                        "process_id": "array_element",
+                        "arguments": {
+                            "data": {
+                                "from_parameter": "data"
+                            },
+                            "index": 1
+                        }
+                    },
+                    "log2": {
+                        "process_id": "log",
+                        "arguments": {
+                            "base": 10,
+                            "x": {
+                                "from_node": "arrayelement2"
+                            }
+                        }
+                    },
+                    "multiply2": {
+                        "process_id": "multiply",
+                        "arguments": {
+                            "x": 10.0,
+                            "y": {
+                                "from_node": "log2"
+                            }
+                        }
+                    },
+                    "add2": {
+                        "process_id": "add",
+                        "arguments": {
+                            "x": {
+                                "from_node": "multiply2"
+                            },
+                            "y": 83.0
+                        }
+                    },
+                    "divide2": {
+                        "process_id": "divide",
+                        "arguments": {
+                            "x": {
+                                "from_node": "add2"
+                            },
+                            "y": 20.0
+                        }
+                    },
+                    "power2": {
+                        "process_id": "power",
+                        "arguments": {
+                            "base": 10,
+                            "p": {
+                                "from_node": "divide2"
+                            }
+                        }
+                    },
+                    "arraycreate1": {
+                        "process_id": "array_create",
+                        "arguments": {
+                            "data": [
+                                {
+                                    "from_node": "power1"
+                                },
+                                {
+                                    "from_node": "power2"
+                                }
+                            ]
+                        },
+                        "result": true
+                    }
+                }
+            }
+        }
+    },
+    "apply1": {
+        "process_id": "apply",
+        "arguments": {
+            "data": {
+                "from_node": "applydimension1"
+            },
+            "process": {
+                "process_graph": {
+                    "linearscalerange1": {
+                        "process_id": "linear_scale_range",
+                        "arguments": {
+                            "inputMax": 65534,
+                            "inputMin": 1,
+                            "outputMax": 65534,
+                            "outputMin": 1,
+                            "x": {
+                                "from_parameter": "x"
+                            }
+                        },
+                        "result": true
+                    }
+                }
+            }
+        },
+        "result": true
+    }
+}

--- a/tests/tests_unit/preprocessing/data/decompress_backscatter_uint16.json
+++ b/tests/tests_unit/preprocessing/data/decompress_backscatter_uint16.json
@@ -1,0 +1,146 @@
+{
+    "loadcollection1": {
+        "process_id": "load_collection",
+        "arguments": {
+            "id": "S1",
+            "spatial_extent": null,
+            "temporal_extent": null
+        }
+    },
+    "applydimension1": {
+        "process_id": "apply_dimension",
+        "arguments": {
+            "data": {
+                "from_node": "loadcollection1"
+            },
+            "dimension": "bands",
+            "process": {
+                "process_graph": {
+                    "arrayelement1": {
+                        "process_id": "array_element",
+                        "arguments": {
+                            "data": {
+                                "from_parameter": "data"
+                            },
+                            "index": 0
+                        }
+                    },
+                    "log1": {
+                        "process_id": "log",
+                        "arguments": {
+                            "base": 10,
+                            "x": {
+                                "from_node": "arrayelement1"
+                            }
+                        }
+                    },
+                    "multiply1": {
+                        "process_id": "multiply",
+                        "arguments": {
+                            "x": 20.0,
+                            "y": {
+                                "from_node": "log1"
+                            }
+                        }
+                    },
+                    "subtract1": {
+                        "process_id": "subtract",
+                        "arguments": {
+                            "x": {
+                                "from_node": "multiply1"
+                            },
+                            "y": 83.0
+                        }
+                    },
+                    "divide1": {
+                        "process_id": "divide",
+                        "arguments": {
+                            "x": {
+                                "from_node": "subtract1"
+                            },
+                            "y": 10.0
+                        }
+                    },
+                    "power1": {
+                        "process_id": "power",
+                        "arguments": {
+                            "base": 10,
+                            "p": {
+                                "from_node": "divide1"
+                            }
+                        }
+                    },
+                    "arrayelement2": {
+                        "process_id": "array_element",
+                        "arguments": {
+                            "data": {
+                                "from_parameter": "data"
+                            },
+                            "index": 1
+                        }
+                    },
+                    "log2": {
+                        "process_id": "log",
+                        "arguments": {
+                            "base": 10,
+                            "x": {
+                                "from_node": "arrayelement2"
+                            }
+                        }
+                    },
+                    "multiply2": {
+                        "process_id": "multiply",
+                        "arguments": {
+                            "x": 20.0,
+                            "y": {
+                                "from_node": "log2"
+                            }
+                        }
+                    },
+                    "subtract2": {
+                        "process_id": "subtract",
+                        "arguments": {
+                            "x": {
+                                "from_node": "multiply2"
+                            },
+                            "y": 83.0
+                        }
+                    },
+                    "divide2": {
+                        "process_id": "divide",
+                        "arguments": {
+                            "x": {
+                                "from_node": "subtract2"
+                            },
+                            "y": 10.0
+                        }
+                    },
+                    "power2": {
+                        "process_id": "power",
+                        "arguments": {
+                            "base": 10,
+                            "p": {
+                                "from_node": "divide2"
+                            }
+                        }
+                    },
+                    "arraycreate1": {
+                        "process_id": "array_create",
+                        "arguments": {
+                            "data": [
+                                {
+                                    "from_node": "power1"
+                                },
+                                {
+                                    "from_node": "power2"
+                                }
+                            ]
+                        },
+                        "result": true
+                    }
+                }
+            }
+        },
+        "result": true
+    }
+}

--- a/tests/tests_unit/preprocessing/test_sar.py
+++ b/tests/tests_unit/preprocessing/test_sar.py
@@ -1,0 +1,35 @@
+import json
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+import openeo_gfmap
+from openeo_gfmap.preprocessing.sar import (
+    compress_backscatter_uint16,
+    decompress_backscatter_uint16,
+)
+
+
+@pytest.fixture
+def mock_backend_context():
+    """Fixture to create a mock backend context."""
+    return MagicMock(spec=openeo_gfmap.BackendContext)
+
+
+def test_compress_backscatter_uint16(s1cube, mock_backend_context):
+    cube = compress_backscatter_uint16(mock_backend_context, s1cube)
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    json_path = os.path.join(test_dir, "data/compress_backscatter_uint16.json")
+    with open(json_path) as f:
+        expected = json.load(f)
+    assert cube.flat_graph() == expected
+
+
+def test_decompress_backscatter_uint16(s1cube, mock_backend_context):
+    cube = decompress_backscatter_uint16(mock_backend_context, s1cube)
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    json_path = os.path.join(test_dir, "data/decompress_backscatter_uint16.json")
+    with open(json_path) as f:
+        expected = json.load(f)
+    assert cube.flat_graph() == expected


### PR DESCRIPTION
Added a `decompress_backscatter_uint16` function, which basically is in the inverse of the `compress_backscatter_uint16` function. This was needed for WorldCereal. Also added some unit tests for both functions. 

We could even consider cherry-picking this to GFMap 1.0.0, let me know your thoughts!