### PR TITLE
support feature_deps via job_options in FeatureExtractor class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- Users can now specify UDF dependencies for the `FeatureExtractor` class via job options, using the `feature_deps` name.
 ### Changed
 
 ### Removed

--- a/src/openeo_gfmap/features/feature_extractor.py
+++ b/src/openeo_gfmap/features/feature_extractor.py
@@ -296,8 +296,6 @@ def _get_imports() -> str:
 
     return "\n".join(imports) + "\n\n" + "\n".join(static_globals)
 
-    return "\n".join(imports) + "\n\n" + "\n".join(static_globals)
-
 
 def _get_apply_udf_data(feature_extractor: FeatureExtractor) -> str:
     source_lines = inspect.getsource(apply_udf_data)

--- a/src/openeo_gfmap/features/feature_extractor.py
+++ b/src/openeo_gfmap/features/feature_extractor.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import re
 import shutil
+import sys
 import urllib.request
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -18,6 +19,8 @@ from openeo.udf import XarrayDataCube
 from openeo.udf.udf_data import UdfData
 from pyproj import Transformer
 from pyproj.crs import CRS
+
+sys.path.append("feature_deps")
 
 LAT_HARMONIZED_NAME = "GEO-LAT"
 LON_HARMONIZED_NAME = "GEO-LON"
@@ -284,12 +287,14 @@ def _get_imports() -> str:
     static_globals = []
 
     for line in lines:
-        if line.strip().startswith(("import ", "from ")):
+        if line.strip().startswith(
+            ("import ", "from ", "sys.path.insert(", "sys.path.append(")
+        ):
             imports.append(line)
-        # All the global variables with the style
-        # UPPER_CASE_GLOBAL_VARIABLE = "constant"
         elif re.match("^[A-Z_0-9]+\s*=.*$", line):
             static_globals.append(line)
+
+    return "\n".join(imports) + "\n\n" + "\n".join(static_globals)
 
     return "\n".join(imports) + "\n\n" + "\n".join(static_globals)
 

--- a/src/openeo_gfmap/inference/model_inference.py
+++ b/src/openeo_gfmap/inference/model_inference.py
@@ -22,7 +22,7 @@ from openeo.udf import XarrayDataCube
 from openeo.udf import inspect as udf_inspect
 from openeo.udf.udf_data import UdfData
 
-sys.path.insert(0, "onnx_deps")
+sys.path.append("onnx_deps")
 import onnxruntime as ort  # noqa: E402
 
 EPSG_HARMONIZED_NAME = "GEO-EPSG"


### PR DESCRIPTION
This change allows user to add dependencies to their FeatureExtractor UDF via the `job_options`, under the name `feature_deps`, instead of having to define a `extract_dependencies` classmethod manually.